### PR TITLE
Improve responsive design

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -181,7 +181,7 @@ export default function Home() {
 
         <section
           id="hero"
-          className="snap-start flex flex-col h-screen px-[10%]"
+          className="snap-start flex flex-col h-screen px-4 md:px-[10%]"
         >
           <header className=" py-6">
             <Header />
@@ -194,7 +194,7 @@ export default function Home() {
 
         <section
           id="about"
-          className="snap-start flex items-center justify-center h-screen px-[10%]"
+          className="snap-start flex items-center justify-center h-screen px-4 md:px-[10%]"
         >
           <div className="grid w-full gap-10 md:grid-cols-2">
             <AboutSection />
@@ -204,16 +204,16 @@ export default function Home() {
 
         <section
           id="projects"
-          className="snap-start flex flex-col items-center justify-center h-screen px-[10%]"
+          className="snap-start flex flex-col items-center justify-center h-screen px-4 md:px-[10%]"
         >
           <ProjectShowcase projects={projects} />
         </section>
 
-        <section id="skills" className="snap-start flex flex-col items-center justify-center h-screen px-[10%]">
+        <section id="skills" className="snap-start flex flex-col items-center justify-center h-screen px-4 md:px-[10%]">
           <SkillsTree />
         </section>
 
-        <section id="contacts" className="snap-start flex flex-col items-center justify-center px-[10%] py-8 h-screen">
+        <section id="contacts" className="snap-start flex flex-col items-center justify-center px-4 md:px-[10%] py-8 h-screen">
           <footer>
             <Footer />
           </footer>

--- a/src/components/AsciiBackground.tsx
+++ b/src/components/AsciiBackground.tsx
@@ -19,7 +19,7 @@ export default function AsciiBackground() {
   }, []);
 
   return (
-    <div className="absolute inset-y-0 right-0 w-3/5 overflow-hidden">
+    <div className="absolute inset-y-0 right-0 w-3/5 overflow-hidden hidden md:block">
       <div className="pointer-events-none absolute inset-y-0 left-0 w-1/6 bg-gradient-to-r from-black/80 to-transparent z-10" />
       <div className="pointer-events-none absolute inset-y-0 right-0 w-1/8 bg-gradient-to-l from-black/80 to-transparent z-10" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-1/4 bg-gradient-to-b from-black/80 to-transparent z-10" />

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,6 +1,7 @@
 "use client";
 import Link from "next/link";
 import { useEffect, useState, MouseEvent } from "react";
+import clsx from "clsx";
 
 const navItems = [
   { name: "Home",     id: "hero"     },
@@ -12,6 +13,7 @@ const navItems = [
 
 export default function Header() {
   const [active, setActive] = useState("hero");
+  const [open, setOpen] = useState(false);
 
   /* подсветка активного пункта — тем же способом, что и SectionNav */
   useEffect(() => {
@@ -36,26 +38,57 @@ export default function Header() {
   ) => {
     e.preventDefault();                 // блокируем стандартный якорь
     document.getElementById(id)?.scrollIntoView({ behavior: "smooth" });
+    setOpen(false);
   };
 
   return (
-    <div className="pt-6 flex justify-between w-full">
+    <div className="pt-6 flex justify-between items-center w-full">
       <div className="text-lg font-semibold">
         <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
       </div>
 
-      <ul className="flex gap-10 text-li font-light">
+      {/* Mobile toggle */}
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-label="Toggle navigation"
+        className="md:hidden p-2"
+      >
+        <svg
+          xmlns="http://www.w3.org/2000/svg"
+          fill="none"
+          viewBox="0 0 24 24"
+          strokeWidth={2}
+          stroke="currentColor"
+          className="h-6 w-6"
+        >
+          <path
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            d="M4 6h16M4 12h16M4 18h16"
+          />
+        </svg>
+      </button>
+
+      <ul
+        className={clsx(
+          "text-li font-light md:flex gap-10",
+          "md:static md:translate-x-0 md:bg-transparent",
+          open
+            ? "flex flex-col absolute right-4 top-full mt-2 bg-black p-4 gap-4 shadow-lg"
+            : "hidden"
+        )}
+      >
         {navItems.map(({ name, id }) => (
           <li key={id}>
             <Link
               href={`#${id}`}
               onClick={(e) => handleClick(e, id)}
-              className={`
-                relative pb-1 transition-all duration-200
-                ${active === id
+              className={clsx(
+                "relative pb-1 transition-all duration-200",
+                active === id
                   ? "border-b-2 border-console-green"
-                  : "hover:text-li-hover"}
-              `}
+                  : "hover:text-li-hover"
+              )}
             >
               {name}
             </Link>

--- a/src/components/HeroSection.tsx
+++ b/src/components/HeroSection.tsx
@@ -1,8 +1,8 @@
 export default function HeroSection() {
   return (
     <section className="relative z-20 max-w-[45ch]">
-      <h1 className="text-lg font-bold tracking-[0.05em]">I'm Tymur&nbsp;Rozhkovskyi</h1>
-      <h2 className="text-5xl font-extrabold mb-4">Web developer</h2>
+      <h1 className="text-base sm:text-lg font-bold tracking-[0.05em]">I'm Tymur&nbsp;Rozhkovskyi</h1>
+      <h2 className="text-4xl sm:text-5xl md:text-6xl font-extrabold mb-4">Web developer</h2>
       <p className="text-xs leading-relaxed text-neutral-400">
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Magnam
         nihil mollitia corporis quis inventore voluptatibus praesentium


### PR DESCRIPTION
## Summary
- add responsive hamburger navigation for mobile
- hide ASCII art on small screens
- adjust hero typography for smaller devices
- reduce side padding on narrow screens

## Testing
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6861b37538d48323a3ce61d5421ca395