### PR TITLE
Optimize mobile scrolling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,9 +168,9 @@ export default function HomePage() {
     <div className="h-screen bg-black text-white font-sans overflow-x-hidden">
       {/* вертикальный snap‑scroll на уровне секций */}
       <SectionNav />
-      <main className="snap-y snap-mandatory scroll-smooth h-screen overflow-y-scroll">
+      <main className="scroll-smooth md:snap-y md:snap-mandatory md:h-screen md:overflow-y-scroll">
         {/* ───────────────────────── Hero ───────────────────────── */}
-        <section id="hero" className="snap-start h-screen flex flex-col px-[10%]">
+        <section id="hero" className="md:snap-start md:h-screen min-h-screen flex flex-col px-[10%]">
           <header className="py-6">
             <Header />
           </header>
@@ -181,7 +181,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── About + part‑1 timeline ───────────────────────── */}
-        <section id="about" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <div className="grid w-full gap-10 md:grid-cols-2">
             <AboutSection />
             {/* левая/правая колонка зависит от md‑breakpoint */}
@@ -190,7 +190,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Timeline continuation ───────────────────────── */}
-        <section id="about-cont" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about-cont" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
 
           <div className="grid w-full gap-10 md:grid-cols-2">
             <SecondAboutSection />
@@ -200,17 +200,17 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Projects ───────────────────────── */}
-        <section id="projects" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="projects" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <ProjectShowcase projects={projects} />
         </section>
 
         {/* ───────────────────────── Skills ───────────────────────── */}
-        <section id="skills" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="skills" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <SkillsTree />
         </section>
 
         {/* ───────────────────────── Contacts / Footer ───────────────────────── */}
-        <section id="contacts" className="snap-start h-screen flex items-center justify-center px-[10%] py-8">
+        <section id="contacts" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%] py-8">
           <footer>
             <Footer />
           </footer>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ export default function Footer() {
     return (
         <footer
             id="contact"
-            className="relative h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
+            className="relative md:h-screen min-h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
         >
             {/* neon pulse line */}
             <div className="pointer-events-none absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-[#5cff96]/0 via-[#5cff96]/70 to-[#5cff96]/0 animate-pulse" />


### PR DESCRIPTION
## Summary
- disable scroll snapping below the `md` breakpoint
- keep footer and sections at minimum screen height on mobile

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_686d14ec74a08323a42b2609d66c336c