### PR TITLE
Disable snap scroll on mobile

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -165,12 +165,12 @@ import SecondAboutSection from "@/components/SecondAboutSection";
  ******************************************************/
 export default function HomePage() {
   return (
-    <div className="h-screen bg-black text-white font-sans overflow-x-hidden">
-      {/* вертикальный snap‑scroll на уровне секций */}
+    <div className="bg-black text-white font-sans overflow-x-hidden md:h-screen">
+      {/* вертикальный snap‑scroll на уровне секций на десктопе */}
       <SectionNav />
-      <main className="snap-y snap-mandatory scroll-smooth h-screen overflow-y-scroll">
+      <main className="scroll-smooth md:h-screen md:overflow-y-scroll md:snap-y md:snap-mandatory">
         {/* ───────────────────────── Hero ───────────────────────── */}
-        <section id="hero" className="snap-start h-screen flex flex-col px-[10%]">
+        <section id="hero" className="flex flex-col px-[10%] md:snap-start md:h-screen">
           <header className="py-6">
             <Header />
           </header>
@@ -181,7 +181,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── About + part‑1 timeline ───────────────────────── */}
-        <section id="about" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about" className="flex items-center justify-center px-[10%] md:snap-start md:h-screen">
           <div className="grid w-full gap-10 md:grid-cols-2">
             <AboutSection />
             {/* левая/правая колонка зависит от md‑breakpoint */}
@@ -190,7 +190,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Timeline continuation ───────────────────────── */}
-        <section id="about-cont" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about-cont" className="flex items-center justify-center px-[10%] md:snap-start md:h-screen">
 
           <div className="grid w-full gap-10 md:grid-cols-2">
             <SecondAboutSection />
@@ -200,17 +200,17 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Projects ───────────────────────── */}
-        <section id="projects" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="projects" className="flex items-center justify-center px-[10%] md:snap-start md:h-screen">
           <ProjectShowcase projects={projects} />
         </section>
 
         {/* ───────────────────────── Skills ───────────────────────── */}
-        <section id="skills" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="skills" className="flex items-center justify-center px-[10%] md:snap-start md:h-screen">
           <SkillsTree />
         </section>
 
         {/* ───────────────────────── Contacts / Footer ───────────────────────── */}
-        <section id="contacts" className="snap-start h-screen flex items-center justify-center px-[10%] py-8">
+        <section id="contacts" className="flex items-center justify-center px-[10%] py-8 md:snap-start md:h-screen">
           <footer>
             <Footer />
           </footer>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ export default function Footer() {
     return (
         <footer
             id="contact"
-            className="relative h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
+            className="relative flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12 md:h-screen"
         >
             {/* neon pulse line */}
             <div className="pointer-events-none absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-[#5cff96]/0 via-[#5cff96]/70 to-[#5cff96]/0 animate-pulse" />

--- a/src/components/RoadmapTimeline.tsx
+++ b/src/components/RoadmapTimeline.tsx
@@ -166,7 +166,7 @@ export default function RoadmapTimeline({
         <section
             ref={ref}
             aria-label="Roadmap timeline"
-            className="relative flex min-h-screen w-full items-center px-5 select-none font-sans"
+            className="relative flex w-full items-center px-5 select-none font-sans md:min-h-screen"
         >
             {/* центральная вертикальная линия */}
             <motion.span


### PR DESCRIPTION
## Summary
- keep snap scrolling only on desktop
- make footer and timeline full height only for desktop

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d14ec74a08323a42b2609d66c336c