### PR TITLE
Optimize mobile scrolling

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,9 +168,9 @@ export default function HomePage() {
     <div className="h-screen bg-black text-white font-sans overflow-x-hidden">
       {/* вертикальный snap‑scroll на уровне секций */}
       <SectionNav />
-      <main className="snap-y snap-mandatory scroll-smooth h-screen overflow-y-scroll">
+      <main className="scroll-smooth md:snap-y md:snap-mandatory md:h-screen md:overflow-y-scroll">
         {/* ───────────────────────── Hero ───────────────────────── */}
-        <section id="hero" className="snap-start h-screen flex flex-col px-[10%]">
+        <section id="hero" className="md:snap-start md:h-screen min-h-screen flex flex-col px-[10%]">
           <header className="py-6">
             <Header />
           </header>
@@ -181,7 +181,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── About + part‑1 timeline ───────────────────────── */}
-        <section id="about" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <div className="grid w-full gap-10 md:grid-cols-2">
             <AboutSection />
             {/* левая/правая колонка зависит от md‑breakpoint */}
@@ -190,7 +190,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Timeline continuation ───────────────────────── */}
-        <section id="about-cont" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="about-cont" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
 
           <div className="grid w-full gap-10 md:grid-cols-2">
             <SecondAboutSection />
@@ -200,17 +200,17 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Projects ───────────────────────── */}
-        <section id="projects" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="projects" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <ProjectShowcase projects={projects} />
         </section>
 
         {/* ───────────────────────── Skills ───────────────────────── */}
-        <section id="skills" className="snap-start h-screen flex items-center justify-center px-[10%]">
+        <section id="skills" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <SkillsTree />
         </section>
 
         {/* ───────────────────────── Contacts / Footer ───────────────────────── */}
-        <section id="contacts" className="snap-start h-screen flex items-center justify-center px-[10%] py-8">
+        <section id="contacts" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%] py-8">
           <footer>
             <Footer />
           </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,9 +168,9 @@ export default function HomePage() {
     <div className="h-screen bg-black text-white font-sans overflow-x-hidden">
       {/* вертикальный snap‑scroll на уровне секций */}
       <SectionNav />
-      <main className="scroll-smooth md:snap-y md:snap-mandatory md:h-screen md:overflow-y-scroll">
+      <main className="scroll-smooth lg:snap-y lg:snap-mandatory lg:h-screen lg:overflow-y-scroll">
         {/* ───────────────────────── Hero ───────────────────────── */}
-        <section id="hero" className="md:snap-start md:h-screen min-h-screen flex flex-col px-[10%]">
+        <section id="hero" className="lg:snap-start lg:h-screen min-h-screen flex flex-col px-[10%]">
           <header className="py-6">
             <Header />
           </header>
@@ -181,7 +181,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── About + part‑1 timeline ───────────────────────── */}
-        <section id="about" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
+        <section id="about" className="lg:snap-start lg:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <div className="grid w-full gap-10 md:grid-cols-2">
             <AboutSection />
             {/* левая/правая колонка зависит от md‑breakpoint */}
@@ -190,7 +190,7 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Timeline continuation ───────────────────────── */}
-        <section id="about-cont" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
+        <section id="about-cont" className="lg:snap-start lg:h-screen min-h-screen flex items-center justify-center px-[10%]">
 
           <div className="grid w-full gap-10 md:grid-cols-2">
             <SecondAboutSection />
@@ -200,17 +200,17 @@ export default function HomePage() {
         </section>
 
         {/* ───────────────────────── Projects ───────────────────────── */}
-        <section id="projects" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
+        <section id="projects" className="lg:snap-start lg:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <ProjectShowcase projects={projects} />
         </section>
 
         {/* ───────────────────────── Skills ───────────────────────── */}
-        <section id="skills" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%]">
+        <section id="skills" className="lg:snap-start lg:h-screen min-h-screen flex items-center justify-center px-[10%]">
           <SkillsTree />
         </section>
 
         {/* ───────────────────────── Contacts / Footer ───────────────────────── */}
-        <section id="contacts" className="md:snap-start md:h-screen min-h-screen flex items-center justify-center px-[10%] py-8">
+        <section id="contacts" className="lg:snap-start lg:h-screen min-h-screen flex items-center justify-center px-[10%] py-8">
           <footer>
             <Footer />
           </footer>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -168,7 +168,7 @@ export default function HomePage() {
     <div className="h-screen bg-black text-white font-sans overflow-x-hidden">
       {/* вертикальный snap‑scroll на уровне секций */}
       <SectionNav />
-      <main className="scroll-smooth lg:snap-y lg:snap-mandatory lg:h-screen lg:overflow-y-scroll">
+      <main className="scroll-smooth">
         {/* ───────────────────────── Hero ───────────────────────── */}
         <section id="hero" className="lg:snap-start lg:h-screen min-h-screen flex flex-col px-[10%]">
           <header className="py-6">

--- a/src/components/ SkillsTree.tsx
+++ b/src/components/ SkillsTree.tsx
@@ -219,7 +219,7 @@ export default function SkillsTree() {
                                 <motion.li
                                     key={skill.name}
                                     variants={item}
-                                    className="mb-1.5 w-44 rounded-md border px-3 py-1 text-center text-[0.7rem] font-medium backdrop-blur"
+                                    className="mb-1.5 w-[70%] rounded-md border px-3 py-1 text-center text-[0.7rem] font-medium backdrop-blur"
                                     style={pillStyle(skill)}
                                 >
                                     {skill.name}

--- a/src/components/ SkillsTree.tsx
+++ b/src/components/ SkillsTree.tsx
@@ -194,7 +194,7 @@ export default function SkillsTree() {
             </ul>
 
             {/* Skills – five columns */}
-            <div className="mt-1 grid grid-cols-1 gap-5 md:grid-cols-5">
+            <div className="mt-1 grid grid-cols-1 gap-5 lg:grid-cols-5">
                 {branches.map((branch, idx) => {
                     const sortedSkills = [...branch.skills].sort((a, b) => a.level - b.level);
                     return (

--- a/src/components/AsciiBackground.tsx
+++ b/src/components/AsciiBackground.tsx
@@ -19,7 +19,7 @@ export default function AsciiBackground() {
   }, []);
 
   return (
-    <div className="hidden md:block absolute inset-y-0 right-0 w-3/5 overflow-hidden select-none">
+    <div className="hidden lg:block absolute inset-y-0 right-0 w-3/5 overflow-hidden select-none">
       <div className="pointer-events-none absolute inset-y-0 left-0 w-1/6 bg-gradient-to-r from-black/80 to-transparent z-10" />
       <div className="pointer-events-none absolute inset-y-0 right-0 w-1/8 bg-gradient-to-l from-black/80 to-transparent z-10" />
       <div className="pointer-events-none absolute inset-x-0 top-0 h-1/4 bg-gradient-to-b from-black/80 to-transparent z-10" />

--- a/src/components/AsciiBackground.tsx
+++ b/src/components/AsciiBackground.tsx
@@ -19,11 +19,14 @@ export default function AsciiBackground() {
   }, []);
 
   return (
-    <div className="absolute inset-0 overflow-hidden flex items-center justify-center select-none">
+    <div className="hidden md:block absolute inset-y-0 right-0 w-3/5 overflow-hidden select-none">
+      <div className="pointer-events-none absolute inset-y-0 left-0 w-1/6 bg-gradient-to-r from-black/80 to-transparent z-10" />
+      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/8 bg-gradient-to-l from-black/80 to-transparent z-10" />
+      <div className="pointer-events-none absolute inset-x-0 top-0 h-1/4 bg-gradient-to-b from-black/80 to-transparent z-10" />
       <pre
         ref={asciiRef}
         aria-hidden
-        className="opacity-70 max-w-none whitespace-pre leading-[2] text-[3px] text-neutral-700 [text-shadow:_0_0_1px_#000]"
+        className="absolute inset-0 max-w-none whitespace-pre leading-[2] text-[3px] text-neutral-600/80 opacity-70 [text-shadow:_0_0_1px_#000]"
       >
         {frame}
       </pre>

--- a/src/components/AsciiBackground.tsx
+++ b/src/components/AsciiBackground.tsx
@@ -19,14 +19,11 @@ export default function AsciiBackground() {
   }, []);
 
   return (
-    <div className="absolute inset-y-0 right-0 w-3/5 overflow-hidden">
-      <div className="pointer-events-none absolute inset-y-0 left-0 w-1/6 bg-gradient-to-r from-black/80 to-transparent z-10" />
-      <div className="pointer-events-none absolute inset-y-0 right-0 w-1/8 bg-gradient-to-l from-black/80 to-transparent z-10" />
-      <div className="pointer-events-none absolute inset-x-0 top-0 h-1/4 bg-gradient-to-b from-black/80 to-transparent z-10" />
+    <div className="absolute inset-0 overflow-hidden flex items-center justify-center select-none">
       <pre
         ref={asciiRef}
         aria-hidden
-        className="absolute inset-0 max-w-none whitespace-pre leading-[2] text-[3px] text-neutral-600/80 [text-shadow:_0_0_1px_#000]"
+        className="opacity-70 max-w-none whitespace-pre leading-[2] text-[3px] text-neutral-700 [text-shadow:_0_0_1px_#000]"
       >
         {frame}
       </pre>

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -97,8 +97,10 @@ export default function Footer() {
             </div>
 
             {/* footer bottom */}
-            <div className="z-10 flex items-center justify-between text-[11px] lg:text-xs text-gray-500 mt-10 lg:mt-0">
-                <span>© {new Date().getFullYear()} Tymur Rozhkovskyi</span>
+            <div className="z-10 flex flex-col items-center gap-6 text-[11px] lg:text-xs text-gray-500 mt-20 lg:mt-0 pb-10">
+
+
+                <span className='mt-10'>© {new Date().getFullYear()} Tymur Rozhkovskyi</span>
 
                 <button
                     onClick={scrollTop}
@@ -116,4 +118,5 @@ export default function Footer() {
                     </svg>
                 </button>
             </div>
-        </footer>    );}
+        </footer>);
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ export default function Footer() {
     return (
         <footer
             id="contact"
-            className="relative md:h-screen min-h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
+            className="relative lg:h-screen min-h-screen flex flex-col justify-between bg-black text-gray-100 px-6 lg:px-24 py-12"
         >
             {/* neon pulse line */}
             <div className="pointer-events-none absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-[#5cff96]/0 via-[#5cff96]/70 to-[#5cff96]/0 animate-pulse" />
@@ -52,11 +52,11 @@ export default function Footer() {
                       bg-[radial-gradient(#5cff96_1px,transparent_1px)]
                       [background-size:6px_6px]" />
             <div className="z-10 flex-1 w-full grid grid-cols-12 gap-10 place-content-center">
-                <div className="col-span-12 md:col-span-6 text-center">
+                <div className="col-span-12 lg:col-span-6 text-center">
                     <h2 className="text-2xl md:text-3xl font-semibold mb-6 tracking-wide ">
                         Services
                     </h2>
-                    <ul className="mx-auto w-fit list-none md:list-disc space-y-2 text-sm md:text-base text-gray-300 md:marker:text-[#5cff96]">
+                    <ul className="mx-auto w-fit list-none lg:list-disc space-y-2 text-sm lg:text-base text-gray-300 lg:marker:text-[#5cff96]">
                         {services.map((item) => (
                             <li key={item} className="leading-snug hover:text-white transition-colors duration-200">
                                 {item}
@@ -66,14 +66,14 @@ export default function Footer() {
                 </div>
 
                 {/* Contact block (spans 6 columns on md+) */}
-                <div className="col-span-12 md:col-span-6 flex flex-col items-center text-center justify-center md:items-end md:text-right mt-14 md:mt-0">
+                <div className="col-span-12 lg:col-span-6 flex flex-col items-center text-center justify-center lg:items-end lg:text-right mt-14 lg:mt-0">
                     <h2 className="text-2xl md:text-3xl font-semibold mb-6 tracking-wide uppercase">
                         Get in touch
                     </h2>
 
                     <a
                         href="mailto:tymurrozhkovskyi@gmail.com"
-                        className="inline-block text-sm md:text-base font-medium text-[#5cff96] hover:underline decoration-[#5cff96]/70 underline-offset-4"
+                        className="inline-block text-sm lg:text-base font-medium text-[#5cff96] hover:underline decoration-[#5cff96]/70 underline-offset-4"
                     >
                         tymurrozhkovskyi@gmail.com
                     </a>
@@ -89,7 +89,7 @@ export default function Footer() {
                                 rel="noopener noreferrer"
                                 className="transition-opacity duration-300 opacity-60 hover:opacity-100 group-hover:opacity-30"
                             >
-                                <img className="w-8 h-8 md:w-6 md:h-6" src={src} alt={alt} />
+                                <img className="w-8 h-8 lg:w-6 lg:h-6" src={src} alt={alt} />
                             </a>
                         ))}
                     </div>
@@ -97,7 +97,7 @@ export default function Footer() {
             </div>
 
             {/* footer bottom */}
-            <div className="z-10 flex items-center justify-between text-[11px] md:text-xs text-gray-500 mt-0">
+            <div className="z-10 flex items-center justify-between text-[11px] lg:text-xs text-gray-500 mt-10 lg:mt-0">
                 <span>© {new Date().getFullYear()} Tymur Rozhkovskyi</span>
 
                 <button
@@ -116,5 +116,4 @@ export default function Footer() {
                     </svg>
                 </button>
             </div>
-        </footer>
-    );}
+        </footer>    );}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -56,7 +56,7 @@ export default function Footer() {
                     <h2 className="text-2xl md:text-3xl font-semibold mb-6 tracking-wide ">
                         Services
                     </h2>
-                    <ul className="mx-auto w-fit list-disc space-y-2 text-sm md:text-base text-gray-300 marker:text-[#5cff96]">
+                    <ul className="mx-auto w-fit list-none md:list-disc space-y-2 text-sm md:text-base text-gray-300 md:marker:text-[#5cff96]">
                         {services.map((item) => (
                             <li key={item} className="leading-snug hover:text-white transition-colors duration-200">
                                 {item}
@@ -97,7 +97,7 @@ export default function Footer() {
             </div>
 
             {/* footer bottom */}
-            <div className="z-10 flex items-center justify-between text-[11px] md:text-xs text-gray-500 mt-10 md:mt-0">
+            <div className="z-10 flex items-center justify-between text-[11px] md:text-xs text-gray-500 mt-0">
                 <span>© {new Date().getFullYear()} Tymur Rozhkovskyi</span>
 
                 <button
@@ -117,5 +117,4 @@ export default function Footer() {
                 </button>
             </div>
         </footer>
-    );
-}
+    );}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -42,7 +42,7 @@ export default function Footer() {
     return (
         <footer
             id="contact"
-            className="relative h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
+            className="relative md:h-screen min-h-screen flex flex-col justify-between bg-black text-gray-100 px-6 md:px-24 py-12"
         >
             {/* neon pulse line */}
             <div className="pointer-events-none absolute bottom-0 left-0 w-full h-px bg-gradient-to-r from-[#5cff96]/0 via-[#5cff96]/70 to-[#5cff96]/0 animate-pulse" />
@@ -52,24 +52,21 @@ export default function Footer() {
                       bg-[radial-gradient(#5cff96_1px,transparent_1px)]
                       [background-size:6px_6px]" />
             <div className="z-10 flex-1 w-full grid grid-cols-12 gap-10 place-content-center">
-                <div className="col-span-12 md:col-span-6">
+                <div className="col-span-12 md:col-span-6 text-center">
                     <h2 className="text-2xl md:text-3xl font-semibold mb-6 tracking-wide ">
                         Services
                     </h2>
-                    <ul className="grid grid-cols-1 sm:grid-cols-2 gap-x-8 gap-y-3 text-sm md:text-base text-gray-300">
+                    <ul className="mx-auto w-fit list-disc space-y-2 text-sm md:text-base text-gray-300 marker:text-[#5cff96]">
                         {services.map((item) => (
-                            <li key={item} className="flex items-start gap-3 group">
-                                <span className="mt-[6px] h-[6px] w-[6px] rounded-full bg-[#5cff96] group-hover:scale-125 transition-transform" />
-                                <span className="leading-snug group-hover:text-white transition-colors duration-200">
-                                    {item}
-                                </span>
+                            <li key={item} className="leading-snug hover:text-white transition-colors duration-200">
+                                {item}
                             </li>
                         ))}
                     </ul>
                 </div>
 
                 {/* Contact block (spans 6 columns on md+) */}
-                <div className="col-span-12 md:col-span-6 flex flex-col justify-center md:items-end mt-14 md:mt-0">
+                <div className="col-span-12 md:col-span-6 flex flex-col items-center text-center justify-center md:items-end md:text-right mt-14 md:mt-0">
                     <h2 className="text-2xl md:text-3xl font-semibold mb-6 tracking-wide uppercase">
                         Get in touch
                     </h2>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,10 +3,10 @@ import Link from "next/link";
 import { useEffect, useState, MouseEvent } from "react";
 
 const navItems = [
-  { name: "Home",     id: "hero"     },
-  { name: "About",    id: "about"    },
+  { name: "Home", id: "hero" },
+  { name: "About", id: "about" },
   { name: "Projects", id: "projects" },
-  { name: "Skills",   id: "skills"   },
+  { name: "Skills", id: "skills" },
   { name: "Contacts", id: "contacts" },
 ];
 
@@ -41,40 +41,42 @@ export default function Header() {
 
   return (
     <>
-      <div className="relative pt-6 flex items-center justify-center w-full">
-        {/* menu icon on small screens and tablets */}
-        <button
-          onClick={() => setMenuOpen(true)}
-          aria-label="Open menu"
-          className="absolute right-0 lg:hidden p-2"
-        >
-          <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
-          </svg>
-        </button>
+      <div className="relative pt-6 w-full">
+        <div className="flex items-center justify-between w-full">
+          {/* logo слева */}
+          <div className="text-lg font-semibold">
+            <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
+          </div>
 
-        {/* logo centered */}
-        <div className="absolute left-1/2 -translate-x-1/2 text-lg font-semibold">
-          <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
+          {/* десктоп навигация справа */}
+          <ul className="hidden lg:flex gap-10 text-li font-light">
+            {navItems.map(({ name, id }) => (
+              <li key={id}>
+                <Link
+                  href={`#${id}`}
+                  onClick={(e) => handleClick(e, id)}
+                  className={`
+              relative pb-1 transition-all duration-200
+              ${active === id ? "text-white" : "hover:text-li-hover"}
+            `}
+                >
+                  {name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+
+          {/* иконка меню (только на мобильных) */}
+          <button
+            onClick={() => setMenuOpen(true)}
+            aria-label="Open menu"
+            className="lg:hidden p-2"
+          >
+            <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+            </svg>
+          </button>
         </div>
-
-        {/* nav list on desktop */}
-        <ul className="hidden lg:flex gap-10 text-li font-light absolute right-0">
-          {navItems.map(({ name, id }) => (
-            <li key={id}>
-              <Link
-                href={`#${id}`}
-                onClick={(e) => handleClick(e, id)}
-                className={`
-                  relative pb-1 transition-all duration-200
-                  ${active === id ? "text-white" : "hover:text-li-hover"}
-                `}
-              >
-                {name}
-              </Link>
-            </li>
-          ))}
-        </ul>
       </div>
 
       {/* mobile menu modal */}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -42,11 +42,11 @@ export default function Header() {
   return (
     <>
       <div className="relative pt-6 flex items-center justify-center w-full">
-        {/* menu icon on small screens */}
+        {/* menu icon on small screens and tablets */}
         <button
           onClick={() => setMenuOpen(true)}
           aria-label="Open menu"
-          className="absolute right-0 md:hidden p-2"
+          className="absolute right-0 lg:hidden p-2"
         >
           <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
             <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
@@ -54,12 +54,12 @@ export default function Header() {
         </button>
 
         {/* logo centered */}
-        <div className="text-lg font-semibold">
+        <div className="absolute left-1/2 -translate-x-1/2 text-lg font-semibold">
           <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
         </div>
 
-        {/* nav list on md+ */}
-        <ul className="hidden md:flex gap-10 text-li font-light absolute right-0">
+        {/* nav list on desktop */}
+        <ul className="hidden lg:flex gap-10 text-li font-light absolute right-0">
           {navItems.map(({ name, id }) => (
             <li key={id}>
               <Link

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -12,6 +12,7 @@ const navItems = [
 
 export default function Header() {
   const [active, setActive] = useState("hero");
+  const [menuOpen, setMenuOpen] = useState(false);
 
   /* подсветка активного пункта — тем же способом, что и SectionNav */
   useEffect(() => {
@@ -39,29 +40,73 @@ export default function Header() {
   };
 
   return (
-    <div className="pt-6 flex justify-between w-full">
-      <div className="text-lg font-semibold">
-        <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
+    <>
+      <div className="relative pt-6 flex items-center justify-center w-full">
+        {/* menu icon on small screens */}
+        <button
+          onClick={() => setMenuOpen(true)}
+          aria-label="Open menu"
+          className="absolute right-0 md:hidden p-2"
+        >
+          <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4 6h16M4 12h16M4 18h16" />
+          </svg>
+        </button>
+
+        {/* logo centered */}
+        <div className="text-lg font-semibold">
+          <Link href="/">m<span className="text-console-green text-xl">1</span>rageLA</Link>
+        </div>
+
+        {/* nav list on md+ */}
+        <ul className="hidden md:flex gap-10 text-li font-light absolute right-0">
+          {navItems.map(({ name, id }) => (
+            <li key={id}>
+              <Link
+                href={`#${id}`}
+                onClick={(e) => handleClick(e, id)}
+                className={`
+                  relative pb-1 transition-all duration-200
+                  ${active === id ? "text-white" : "hover:text-li-hover"}
+                `}
+              >
+                {name}
+              </Link>
+            </li>
+          ))}
+        </ul>
       </div>
 
-      <ul className="flex gap-10 text-li font-light">
-        {navItems.map(({ name, id }) => (
-          <li key={id}>
-            <Link
-              href={`#${id}`}
-              onClick={(e) => handleClick(e, id)}
-              className={`
-                relative pb-1 transition-all duration-200
-                ${active === id
-                  ? "text-white"
-                  : "hover:text-li-hover"}
-              `}
-            >
-              {name}
-            </Link>
-          </li>
-        ))}
-      </ul>
-    </div>
+      {/* mobile menu modal */}
+      {menuOpen && (
+        <div className="fixed inset-0 z-50 flex flex-col items-center justify-center bg-black/90">
+          <button
+            onClick={() => setMenuOpen(false)}
+            aria-label="Close menu"
+            className="absolute top-6 right-6 p-2"
+          >
+            <svg className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="2" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+          <ul className="space-y-6 text-xl">
+            {navItems.map(({ name, id }) => (
+              <li key={id}>
+                <Link
+                  href={`#${id}`}
+                  onClick={(e) => {
+                    handleClick(e, id);
+                    setMenuOpen(false);
+                  }}
+                  className="block px-4 py-2"
+                >
+                  {name}
+                </Link>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+    </>
   );
 }

--- a/src/components/ProjectShowcase.tsx
+++ b/src/components/ProjectShowcase.tsx
@@ -45,9 +45,7 @@ export default function ProjectShowcase({ projects }: ProjectShowcaseProps) {
   return (
     <section className="w-full">
       <header className="mb-10 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
-        <h2 className="text-4xl font-bold tracking-tight bg-gradient-to-r from-console-green via-white to-console-green/60 bg-clip-text select-none">
-          Projects
-        </h2>
+        <h2 className="text-4xl font-bold tracking-tight select-none">Projects</h2>
 
         <nav className="flex gap-2 overflow-x-auto pb-1 scrollbar-none">
           {filters.map((f) => (


### PR DESCRIPTION
## Summary
- disable scroll snapping below the `md` breakpoint
- keep footer and sections at minimum screen height on mobile
- center mobile menu with modal navigation
- center ASCII art and disable text selection
- widen skill pills to 70%

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm install` *(fails: network access blocked)*


------
https://chatgpt.com/codex/tasks/task_e_686d14ec74a08323a42b2609d66c336c